### PR TITLE
Fix a minor typo in the hvp article

### DIFF
--- a/hvp.html
+++ b/hvp.html
@@ -231,7 +231,7 @@ x_n} \\
 \begin{bmatrix}
 \sum_i  \frac{\partial^2 f(x)}{\partial x_i \partial x_1} v_i \\
 \vdots \\
-\sum_i  \frac{\partial^2 f(x)}{\partial x_i \partial x_1} v_n \\
+\sum_i  \frac{\partial^2 f(x)}{\partial x_i \partial x_n} v_i \\
 \end{bmatrix}
 \]</span></p>
 <p>This result aligns precisely with the definition of the HVP.</p>

--- a/hvp.md
+++ b/hvp.md
@@ -100,7 +100,7 @@ $$
 \begin{bmatrix}
 \sum_i  \frac{\partial^2 f(x)}{\partial x_i \partial x_1} v_i \\
 \vdots \\
-\sum_i  \frac{\partial^2 f(x)}{\partial x_i \partial x_1} v_n \\
+\sum_i  \frac{\partial^2 f(x)}{\partial x_i \partial x_n} v_i \\
 \end{bmatrix}
 $$
 


### PR DESCRIPTION
There is a minor typo on the variable subscripts in the last equation. The PR fixes the typo.